### PR TITLE
fix: remove licenses from dep5 that are specified directly

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -2,23 +2,3 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: iris-keycloak-charts
 Upstream-Contact: Deutsche Telekom AG <opensource@telekom.de>
 Source: https://github.com/telekom/iris-keycloak-charts
-
-Files: charts/*
-Copyright: The original authors
-License: Apache-2.0
-
-Files: platforms/*
-Copyright: The original authors
-License: Apache-2.0
-
-Files: templates/*
-Copyright: The original authors
-License: Apache-2.0
-
-Files: templates/*
-Copyright: The original authors
-License: Apache-2.0
-
-Files: values.yaml, Chart.yaml
-Copyright: The original authors
-License: Apache-2.0


### PR DESCRIPTION
@valenok4000 apologies, I have been unclear on the dep5, I updated it now.

Basically usually it only has the header content but no license statements, only in exceptional cases we have license statements in there :) 