### PR TITLE
Fixed check-database init container image value reference.

### DIFF
--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -93,7 +93,7 @@ spec:
         {{- include "keycloak.db.certificates.volumeMount" $ | indent 8 }}
       initContainers:
       - name: "check-database"
-        image: {{ .Values.image }}
+        image: {{ .Values.postgresql.image }}
         imagePullPolicy: {{ .Values.postgresql.imagePullPolicy | default .Values.global.imagePullPolicy }}
         command: ['/bin/bash']
         args: ['-c', 'until pg_isready -U {{ .Values.global.database.username }}; do echo waiting for database; sleep 2; done;']


### PR DESCRIPTION
Adjusted the faulty image name value reference of the init container. This container checks the database connection before iris startup. 