### PR TITLE
General Updates to Helm templates

### DIFF
--- a/charts/postgresql/templates/_common.tpl
+++ b/charts/postgresql/templates/_common.tpl
@@ -3,7 +3,7 @@
 imagePullSecrets:
 {{- range .Values.global.imagePullSecrets }}
 {{- if not (kindIs "string" .) }}
-  - name: {{ $.Release.Name }}-{{ .name }}
+  - name: {{ .name }}
 {{- else }}
   - name: {{ . }}
 {{- end -}}

--- a/templates/_common.tpl
+++ b/templates/_common.tpl
@@ -3,7 +3,7 @@
 imagePullSecrets:
 {{- range .Values.global.imagePullSecrets }}
 {{- if not (kindIs "string" .) }}
-  - name: {{ $.Release.Name }}-{{ .name }}
+  - name: {{ .name }}
 {{- else }}
   - name: {{ . }}
 {{- end -}}

--- a/templates/_keycloak.tpl
+++ b/templates/_keycloak.tpl
@@ -132,13 +132,13 @@ checksum/{{ . }}: {{ include (print $.Template.BasePath "/" . ) $ | sha256sum }}
 {{ end -}}
 
 {{- define "keycloak.ingress.tlsSecret" -}}
-{{- if not (and (empty .Values.ingress.tlsSecret) (empty .Values.global.ingress.tlsSecret)) -}}
-secretName: {{ .Values.ingress.tlsSecret | default .Values.global.ingress.tlsSecret -}}
+{{- if not (and (empty .Values.ingress.tlsSecret) (empty .Values.ingress.tlsSecret)) -}}
+secretName: {{ .Values.ingress.tlsSecret | default .Values.ingress.tlsSecret -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "keycloak.ingress.ingressClassName" -}}
-{{- if or (include "platformSpecificValue" (list $ . ".Values.ingress.ingressClassName")) (include "platformSpecificValue" (list $ . ".Values.global.ingress.ingressClassName")) -}}
-ingressClassName: {{ include "platformSpecificValue" (list $ . ".Values.ingress.ingressClassName") | default (include "platformSpecificValue" (list $ . ".Values.global.ingress.ingressClassName")) }}
+{{- if or (include "platformSpecificValue" (list $ . ".Values.ingress.ingressClassName")) (include "platformSpecificValue" (list $ . ".Values.ingress.ingressClassName")) -}}
+ingressClassName: {{ include "platformSpecificValue" (list $ . ".Values.ingress.ingressClassName") | default (include "platformSpecificValue" (list $ . ".Values.ingress.ingressClassName")) }}
 {{- end -}}
 {{- end -}}

--- a/templates/ingress.yml
+++ b/templates/ingress.yml
@@ -6,6 +6,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ .Release.Name }}
   labels: {{ include "keycloak.labels" $ | nindent 4 }}
 spec:

--- a/templates/secret.yml
+++ b/templates/secret.yml
@@ -9,6 +9,6 @@ metadata:
   labels: {{ include "keycloak.labels" $ | nindent 4 }}
 type: Opaque
 stringData:
-  adminPassword: admin
-  databasePassword: pwd
+  adminPassword: {{ .Values.global.database.adminPassword }}
+  databasePassword: {{ .Values.global.database.password }}
   truststore.jks: {{ .Values.truststore | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -13,13 +13,7 @@ global:
   labels:
     # fluentd label
   product: "iris_keycloak"
-  ingress:
-    #tlsSecret: ""
-    #ingressClassName: ""
-    annotations:
-      {}
-      #external-dns.alpha.kubernetes.io/target: ""
-      #kubernetes.io/ingress.class: ""
+
 
   # If imagePullSecrets is not empty, a pull secret will be deployed for each entry otherwise
   # no pull secret will be deployed
@@ -178,9 +172,15 @@ ingress:
   #altHostname: ""
   # overwrite host used in KC_HOSTNAME
   #adminHostname: ""
-  #tlsSecret: ""
-  #ingressClassName: ""
+  tlsSecret: ""
+  ingressClassName: "nginx"
   annotations: {}
+    # external-dns.alpha.kubernetes.io/target: ""
+    # kubernetes.io/ingress.class: ""
+
+    ## With multiple replicas it might be necessary to add below cookie options to the ingress.
+    # nginx.ingress.kubernetes.io/affinity: 'cookie'
+    # nginx.ingress.kubernetes.io/session-cookie-path: '/'
 
 prometheus:
   enabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -46,6 +46,7 @@ global:
     database: pgdb
     username: pgusr
     password: not_secure_pwd
+    adminPassword: changeme
 
   failOnUnsetValues: true
 


### PR DESCRIPTION
Hey there!

I included 3 changes in the templates which I had to make for my deployment and I think they would be good additions for the chart:

- Due to generally having one pullsecret in a namespace for remote repos I removed the Release's name from the created template. This way we can use the exact name of the secret without having the chart's name in it, and won't have to make separate secrets for each chart.

- Added an annotations field to the ingress template at `templates/ingress.yml` that points to `.Values.ingress.annotations` if it's not empty, as it was missing. Also pointed all ingress templating to the `.Values.ingress` object instead of the one in `.Values.global.ingress` to avoid confusion.

- In `templates/secret.yaml` there are two hardcoded passwords (`adminPassword` and `databasePassword`). These were switched to take the values of `.Values.global.database.password` and `.Values.global.database.adminPassword` keys from values file. Not sure if you intended `.Values.adminPassword` for this, but I created a new one to be sure, as the comment say that one is for Keycloak admin role credentials.

If any points need clarification or modification please let me know.