### PR TITLE
Added headless service needed for Infinispan cluster discovery.

### DIFF
--- a/templates/service-headless.yml
+++ b/templates/service-headless.yml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-jgroups
+  labels: {{ include "keycloak.labels" $ | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector: {{ include "keycloak.selector" $ | nindent 4 }}


### PR DESCRIPTION
In order to run Keycloak as a multi-replica setup, the distributed cache based on Infinispan needs to discover other instances.

This is done via a headless service.
