### PR TITLE
chore: updated deprecated environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ SPDX-License-Identifier: CC0-1.0
 
 # Changelog
 
+## [1.2.1]
+### Changed
+- Updated deprecated environment variable `KEYCLOAK_ADMIN` to `KC_BOOTSTRAP_ADMIN_USERNAME`.
+- Updated deprecated environment variable `KEYCLOAK_ADMIN_PASSWORD` to `KC_BOOTSTRAP_ADMIN_PASSWORD`.
+
 ## [1.2.0]
 ### Added
 - Configuration for **HorizontalPodAutoscaler**.

--- a/templates/_keycloak.tpl
+++ b/templates/_keycloak.tpl
@@ -59,9 +59,9 @@ checksum/{{ . }}: {{ include (print $.Template.BasePath "/" . ) $ | sha256sum }}
   value: "true"
 - name: CLIENT_AUTH_METHOD_METRICS_ENABLED
   value: {{ .Values.clientAuthMethodMetricsEnabled | quote }}
-- name: KEYCLOAK_ADMIN
+- name: KC_BOOTSTRAP_ADMIN_USERNAME
   value: {{ .Values.adminUsername }}
-- name: KEYCLOAK_ADMIN_PASSWORD
+- name: KC_BOOTSTRAP_ADMIN_PASSWORD
   valueFrom:
     secretKeyRef:
       name: {{ .Release.Name }}


### PR DESCRIPTION
Two env variables were labeled as deprecated and adjusted to the functional equivalent:
`KEYCLOAK_ADMIN` --> `KC_BOOTSTRAP_ADMIN_USERNAME`
`KEYCLOAK_ADMIN_PASSWORD` --> `KC_BOOTSTRAP_ADMIN_PASSWORD`