### PR TITLE
feat: support configurable TLS hostnames in Ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ SPDX-License-Identifier: CC0-1.0
 
 # Changelog
 
+## [1.2.2]
+### Changed
+- Refactored Ingress TLS configuration to support flexible hostname management:
+    - Introduced `ingress.tls.enabled`, `ingress.tls.hosts`, and `ingress.tls.secret` fields in `values.yaml`.
+    - Deprecated `ingress.tlsSecret` in favor of `ingress.tls.secret`.
+    - Updated templates to reflect new structure for improved flexibility and consistency.
+
 ## [1.2.1]
 ### Changed
 - Updated deprecated environment variable `KEYCLOAK_ADMIN` to `KC_BOOTSTRAP_ADMIN_USERNAME`.

--- a/templates/_keycloak.tpl
+++ b/templates/_keycloak.tpl
@@ -145,9 +145,19 @@ checksum/{{ . }}: {{ include (print $.Template.BasePath "/" . ) $ | sha256sum }}
 {{- $mergedAnnotations | toYaml -}}
 {{ end -}}
 
-{{- define "keycloak.ingress.tlsSecret" -}}
-{{- if not (and (empty .Values.ingress.tlsSecret) (empty .Values.global.ingress.tlsSecret)) -}}
-secretName: {{ .Values.ingress.tlsSecret | default .Values.global.ingress.tlsSecret -}}
+{{- define "keycloak.tls.secret" -}}
+{{- if not (and (empty .Values.ingress.tls.secret) (empty .Values.global.ingress.tlsSecret)) -}}
+secretName: {{ .Values.ingress.tls.secret | default .Values.global.ingress.tlsSecret -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "keycloak.tls.hosts" -}}
+{{- if or (not .Values.ingress.tls.hosts) (eq (len .Values.ingress.tls.hosts) 0) -}}
+- {{ include "keycloak.host" . }}
+{{- else -}}
+{{- range .Values.ingress.tls.hosts }}
+- {{ . }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/templates/ingress.yml
+++ b/templates/ingress.yml
@@ -30,12 +30,10 @@ spec:
               number: 80
 {{- end }}
 {{- include "keycloak.ingress.ingressClassName" . | nindent 2 }}
+{{- if .Values.ingress.tls.enabled }}
   tls:
   - hosts:
-    - {{ include "keycloak.host" . }}
-{{- if not (empty .Values.ingress.altHostname) }}
-    - {{ .Values.ingress.altHostname }}
-    secretName: {{ .Release.Namespace }}-wildcard
+{{- include "keycloak.tls.hosts" . | nindent 4 -}}
+{{- include "keycloak.tls.secret" . | nindent 4 -}}
 {{- end }}
-{{- include "keycloak.ingress.tlsSecret" . | nindent 4 -}}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -209,8 +209,11 @@ ingress:
   hostname: localhost
 #  altHostname: ""   # alternative second host name in ingress
 #  adminHostname: ""   # overwrite host used in KC_HOSTNAME
-#  tlsSecret: ""
 #  ingressClassName: "nginx"
+  tls:
+    enabled: true   # Enable TLS section in Ingress (HTTPS support)
+    hosts: []       # List of TLS hostnames; default is ingress.hostname
+    secret: ""      # Secret name containing TLS certificate
   annotations: {}
 #    # With multiple replicas it might be necessary to add below cookie options to the ingress.
 #    nginx.ingress.kubernetes.io/affinity: 'cookie'


### PR DESCRIPTION
### ✨ What’s Changed

- Introduced new fields in `values.yaml`:
  - `ingress.tls.enabled`: toggle TLS support
  - `ingress.tls.hosts`: explicitly define TLS hostnames
  - `ingress.tls.secret`: define the TLS secret name
- Deprecated `ingress.tlsSecret` in favor of `ingress.tls.secret`
- Updated templates to use the new structure for improved clarity and maintainability

### 🧩 Motivation

The previous implementation lacked flexibility for environments requiring multiple or non-default TLS hostnames. These changes aim to make TLS configuration more intuitive, especially in multi-domain deployments.

### 🛠️ Migration Notes

- If you currently use `ingress.tlsSecret`, please migrate to the new `ingress.tls.secret` field.
- Set `ingress.tls.enabled: true` and configure `ingress.tls.hosts` accordingly.