### PR TITLE
fix: enable Infinispan cluster discovery via Kubernetes DNS stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ SPDX-License-Identifier: CC0-1.0
 
 # Changelog
 
+## [1.2.3]
+### Fixed
+- Resolved issue with `401 Unauthorized` errors when running multiple Keycloak replicas:
+    - Added `--cache-stack=kubernetes` to support JGroups-based Infinispan discovery in Kubernetes.
+
 ## [1.2.2]
 ### Changed
 - Refactored Ingress TLS configuration to support flexible hostname management:

--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -75,6 +75,7 @@ spec:
           - "--import-realm"
           {{- if .Values.infinispan.enabled }}
           - "--cache=ispn"
+          - "--cache-stack=kubernetes"
           {{- end }}
         env:
         {{- include "keycloak.env" $ | indent 8 }}


### PR DESCRIPTION
### 🛠 Problem

When running multiple replicas of Keycloak, a portion of authentication requests failed with `401 Unauthorized` due to missing session synchronization. This was caused by each pod maintaining an isolated local Infinispan cache without any inter-node communication.

---

### ✅ Solution

Enabled **Kubernetes-based JGroups discovery** by adding the `--cache-stack=kubernetes` startup argument. This allows Keycloak pods to form a cluster using DNS-based discovery and share session/cache state through Infinispan.
