### PR TITLE
docs: remove note about AWS EKS as a recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: CC0-1.0
 ## Overview
 
 This chart installs [Keycloak](https://www.keycloak.org/documentation.html). \
-It is suitable for installations on AWS EKS. Recommended to use with customized keycloak docker \
+Recommended to use with customized keycloak docker \
 image (see the links section). \
 Default settings in this template are prepared for non-prod environments.
 


### PR DESCRIPTION
Fixes #15

Our Helm charts are designed to be hyperscaler agnostic. The only necessary requirement is a Kubernetes cluster. Therefore, I have removed the note from the README indicating that the Helm chart was specifically designed for AWS EKS. The Helm chart can also be installed on other K8s platforms.