### PR TITLE
chore: replace deprecated JDBC_PARAMS config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ SPDX-License-Identifier: CC0-1.0
 
 # Changelog
 
+## [1.2.5]
+### Refactored
+- Replaced deprecated `JDBC_PARAMS` with `KC_DB_URL_PROPERTIES` for Keycloak external database SSL configuration
+
 ## [1.2.4]
 ### Refactored
 - Removed platform-specific values files, refactored template configuration

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,7 +4,7 @@
 
 apiVersion: v2
 name: iris_keycloak
-version: 1.2.4
+version: 1.2.5
 appVersion: 1.1.0
 keywords:
   - iris_keycloak

--- a/templates/_keycloak.tpl
+++ b/templates/_keycloak.tpl
@@ -20,8 +20,8 @@ checksum/{{ . }}: {{ include (print $.Template.BasePath "/" . ) $ | sha256sum }}
 {{- end -}}
 {{- end -}}
 
-{{- define "keycloak.jdbcParams" -}}
-{{- $ssl := "true" }}
+{{- define "keycloak.dbUrlProperties" -}}
+{{- $ssl := .Values.externalDatabase.ssl | default "true" }}
 {{- $sslMode := .Values.externalDatabase.sslMode | default "verify-full" }}
 {{- $sslCert := "" }}
 {{- $sslKey := "" }}
@@ -37,7 +37,7 @@ checksum/{{ . }}: {{ include (print $.Template.BasePath "/" . ) $ | sha256sum }}
 {{- $sslRootCert = "&sslrootcert=/certificates/sslrootcert.crt" }}
 {{- end -}}
 
-{{- printf "ssl=%s&sslmode=%s%s%s%s" $ssl $sslMode $sslCert $sslKey $sslRootCert -}}
+{{- printf "?ssl=%s&sslmode=%s%s%s%s" $ssl $sslMode $sslCert $sslKey $sslRootCert -}}
 {{ end -}}
 
 {{- define "keycloak.url" }}
@@ -88,8 +88,8 @@ checksum/{{ . }}: {{ include (print $.Template.BasePath "/" . ) $ | sha256sum }}
       name: {{ .Release.Name }}
       key: databasePassword
 {{- if .Values.externalDatabase.ssl }}
-- name: JDBC_PARAMS
-  value: {{ include "keycloak.jdbcParams" $ | quote }}
+- name: KC_DB_URL_PROPERTIES
+  value: {{ include "keycloak.dbUrlProperties" $ | quote }}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
### 📌 Summary

Replace the deprecated `JDBC_PARAMS` environment variable with the official and up-to-date `KC_DB_URL_PROPERTIES`, aligning with current Keycloak configuration standards.

### 📚 Reference

* Keycloak 17+ switched from `JDBC_PARAMS` to `KC_DB_URL_PROPERTIES`:
  [https://www.keycloak.org/server/db#\_setting-the-database-connection](https://www.keycloak.org/server/db#_setting-the-database-connection)
* Clarification on KC_DB_URL_PROPERTIES format (must start with ?): [Clearify the use of db-url-properties](https://github.com/keycloak/keycloak/issues/12720)
