### PR TITLE
chore: add GitHub Action for automatic Helm chart version bump on tag creation

### DIFF
--- a/.github/workflows/helm-chart-bumb.yml
+++ b/.github/workflows/helm-chart-bumb.yml
@@ -10,7 +10,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+*'        # trigger on any SemVer tag, e.g. 1.2.3
 
 env:
-  TARGET_BRANCH: chore/chart-bump
+  TARGET_BRANCH: main
 
 jobs:
   bump:

--- a/.github/workflows/helm-chart-bumb.yml
+++ b/.github/workflows/helm-chart-bumb.yml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2025 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: bump-chart-on-tag
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+*'        # trigger on any SemVer tag, e.g. 1.2.3
+
+env:
+  TARGET_BRANCH: chore/chart-bump
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0                # need full history for git-graph queries
+
+      - name: Install yq                # lightweight YAML processor
+        uses: mikefarah/yq@v4
+
+      - name: Check out target branch
+        run: git switch ${{ env.TARGET_BRANCH }}
+
+      - name: Bump chart version with yq
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          yq -i ".version = \"${VERSION}\"" Chart.yaml
+
+      - name: Commit and push changes
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Chart.yaml
+          git commit -m "chore(chart): bump to ${GITHUB_REF_NAME}"
+          git push

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,7 +4,7 @@
 
 apiVersion: v2
 name: iris_keycloak
-version: 1.2.4
+version: 9.9.7
 appVersion: 1.1.0
 keywords:
   - iris_keycloak

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,7 +4,7 @@
 
 apiVersion: v2
 name: iris_keycloak
-version: 9.9.7
+version: 1.2.4
 appVersion: 1.1.0
 keywords:
   - iris_keycloak


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow that automatically updates the `version` field in `Chart.yaml` when a new SemVer tag is pushed (e.g. `1.2.3`). The version is parsed from the tag name and committed back to the repository.

### Test & Validation

The workflow was tested in a test branch (`chore/chart-bump`) using a temporary tag `9.9.7` ([link](https://github.com/telekom/identity-iris-keycloak-charts/tags)).

This tag triggered a successful bump and commit as expected. The change was subsequently **reverted** to keep the history clean.
