### PR TITLE
fix: use specific Keycloak image version instead of 'latest'

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Enforce conventional commit messages
+name: Commit Message Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Install commitlint and config
+        run: |
+          npm install --global @commitlint/cli @commitlint/config-conventional
+
+      - name: Lint commits
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+          else
+            npx commitlint --last --verbose
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ SPDX-License-Identifier: CC0-1.0
 
 # Changelog
 
+## [1.2.6]
+### Fixed
+- Updated `values.yaml` to use a fixed Docker image tag for Keycloak instead of `latest`, improving reproducibility and clarity.
+
 ## [1.2.5]
 ### Refactored
 - Replaced deprecated `JDBC_PARAMS` with `KC_DB_URL_PROPERTIES` for Keycloak external database SSL configuration

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,7 +4,7 @@
 
 apiVersion: v2
 name: iris_keycloak
-version: 1.2.5
+version: 1.2.6
 appVersion: 1.1.0
 keywords:
   - iris_keycloak

--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ By participating in this project, you agree to abide by its [Code of Conduct](./
 This project follows the [REUSE standard for software licensing](https://reuse.software/).
 Each file contains copyright and license information, and license texts can be found in the [./LICENSES](./LICENSES) folder. For more information visit https://reuse.software/.
 
+## Conventional CommitsAdd commentMore actions
+
+This project enforces [Conventional Commits](https://www.conventionalcommits.org/) for all commits.
+**All commit messages must follow the Conventional Commits specification.**
+This is automatically checked in CI for both pushes and pull requests.
+
 ### REUSE
 
 The [reuse tool](https://github.com/fsfe/reuse-tool) can be used to verify and establish compliance when new files are added. 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
+// SPDX-License-Identifier: Apache-2.0
+
+// Configuration file for commitlint to enforce Conventional Commits in this repository.
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+};

--- a/values.yaml
+++ b/values.yaml
@@ -24,7 +24,7 @@ global:
       # kubernetes.io/ingress.class: ""
   image:
     repository: iris_keycloak
-    tag: latest
+    tag: 1.1.1
     pullPolicy: IfNotPresent
   # If imagePullSecrets is not empty, a pull secret will be deployed for each entry otherwise
   # no pull secret will be deployed


### PR DESCRIPTION
### 🔧 Summary

This PR replaces the `latest` Keycloak image tag in `values.yaml` with a specific version (`1.1.1`).

### 🧾 Also included

* Added commit message linting via GitHub Actions

### 🔗 Related

Fixes #14
