### PR TITLE
fix: update health probe paths to match actual Keycloak endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ SPDX-License-Identifier: CC0-1.0
 
 # Changelog
 
+## [1.2.7]
+### Fixed
+- Corrected `startup`, `readiness`, and `liveness` probe paths in `values.yaml` to match actual Keycloak health check endpoints.
+
 ## [1.2.6]
 ### Fixed
 - Updated `values.yaml` to use a fixed Docker image tag for Keycloak instead of `latest`, improving reproducibility and clarity.

--- a/values.yaml
+++ b/values.yaml
@@ -24,7 +24,7 @@ global:
       # kubernetes.io/ingress.class: ""
   image:
     repository: iris_keycloak
-    tag: 1.1.1
+    tag: 1.1.2
     pullPolicy: IfNotPresent
   # If imagePullSecrets is not empty, a pull secret will be deployed for each entry otherwise
   # no pull secret will be deployed
@@ -170,22 +170,22 @@ resources:
 
 livenessProbe: |-
   httpGet:
-    path: '/auth/'
-    port: 8080
+    path: '/auth/health/live'
+    port: 9000
   initialDelaySeconds: 300
   timeoutSeconds: 5
 
 readinessProbe: |-
   httpGet:
-    path: '/auth/realms/master'
-    port: 8080
+    path: '/auth/health/ready'
+    port: 9000
   initialDelaySeconds: 30
   timeoutSeconds: 2
 
 startupProbe: |-
   httpGet:
-    path: '/auth/'
-    port: 8080
+    path: '/auth/health/started'
+    port: 9000
   initialDelaySeconds: 30
   timeoutSeconds: 2
   failureThreshold: 60


### PR DESCRIPTION
<p>This PR fixes incorrect <code inline="">startup</code>, <code inline="">readiness</code>, and <code inline="">liveness</code> probe paths in <code inline="">values.yaml</code> for the Keycloak deployment.</p>
<p>Updated probe paths to use the correct Keycloak health endpoints:</p>

Probe Type | Old Path | New Path
-- | -- | --
startupProbe | /auth/ | /auth/health/started
readinessProbe | /auth/realms/master | /auth/health/ready
livenessProbe | /auth/ | /auth/health/live

<hr>
<h3>📚 Reference</h3>
<ul>
<li>
<p>Official guide: <a href="https://www.keycloak.org/guides#observability">Tracking instance status with health checks – Keycloak</a></p>
</li>
</ul>
<hr>

<h3>🔗 Related image changes</h3>
<ul>

<p>These updated endpoints are only available because we recently removed the deprecated <code inline="">--legacy-observability-interface=true</code> flag from the Keycloak Docker image.</p>
<p>See: <a href="https://github.com/telekom/identity-iris-keycloak-image/pull/8">[Remove legacy observability interface flag from Dockerfile]</a></p>