### PR TITLE
fix: add missing db port configuration to check db init container

### DIFF
--- a/templates/_keycloak.tpl
+++ b/templates/_keycloak.tpl
@@ -96,6 +96,8 @@ checksum/{{ . }}: {{ include (print $.Template.BasePath "/" . ) $ | sha256sum }}
 {{- define "keycloak.checkdatabase.env" }}
 - name: PGHOST
   value: {{ include "database.host" $ }}
+- name: PGPORT
+  value: {{ .Values.global.database.port | default "5432" | quote }}
 - name: PGDATABASE
   value: {{ .Values.global.database.database }}
 - name: PGUSER


### PR DESCRIPTION
Added db port to check database init container to account for non-standard postgres port.