### PR TITLE
fix: changed label values to map

### DIFF
--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -5,15 +5,15 @@
 global:
   labels:
     # Common labels for all resources
-    common: []
+    common: {}
     # Monitoring related Labels
     monitoring:
       # General monitoring labels
-      general: []
+      general: {}
       # Labels for monitoring specific to Keycloak service
-      keycloak: []
+      keycloak: {}
       # Labels for monitoring database services
-      database: []
+      database: {}
 
   imagePullSecrets: []
 

--- a/values.yaml
+++ b/values.yaml
@@ -7,15 +7,15 @@ global:
   domain: ""
   labels:
     # Common labels for all resources
-    common: []
+    common: {}
     # Monitoring related Labels
     monitoring:
       # General monitoring labels
-      general: []
+      general: {}
       # Labels for monitoring specific to Keycloak service
-      keycloak: []
+      keycloak: {}
       # Labels for monitoring database services
-      database: []
+      database: {}
   product: "iris_keycloak"
   ingress:
     # tlsSecret: ""


### PR DESCRIPTION
Hi!

This PR changes default values from array to map, as helm is throwing errors when we are using maps in custom values, while the default value file expects an array.