### PR TITLE
feat: harmonize the way image specfic configuration will be set and used

### DIFF
--- a/charts/postgresql/templates/_common.tpl
+++ b/charts/postgresql/templates/_common.tpl
@@ -10,3 +10,30 @@ imagePullSecrets:
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Construct the full image name following the Bitnami pattern.
+Usage: {{ include "common.image" (dict "imageRoot" .Values.path.to.image "global" .Values.global) }}
+Parameters:
+  - imageRoot: The image configuration object (must contain: registry, repository, tag, digest)
+  - global: The global values object (must contain: imageRegistry)
+Returns: registry/repository:tag or registry/repository@digest
+*/}}
+{{- define "common.image" -}}
+  {{- $registryName := .imageRoot.registry -}}
+  {{- if not $registryName -}}
+    {{- $registryName = .global.imageRegistry -}}
+  {{- end -}}
+  {{- $repositoryName := .imageRoot.repository -}}
+  {{- $separator := ":" -}}
+  {{- $termination := .imageRoot.tag | toString -}}
+  {{- if .imageRoot.digest -}}
+    {{- $separator = "@" -}}
+    {{- $termination = .imageRoot.digest | toString -}}
+  {{- end -}}
+  {{- if $registryName -}}
+    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
+  {{- else -}}
+    {{- printf "%s%s%s" $repositoryName $separator $termination -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/postgresql/templates/deployment.yml
+++ b/charts/postgresql/templates/deployment.yml
@@ -35,7 +35,7 @@ spec:
         resources: {{ .Values.resources | toYaml | nindent 10 }}
         env:
         {{- include "postgresql.env" $ | indent 8 }}
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        image: {{ include "common.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
         imagePullPolicy: {{ .Values.image.pullPolicy | default .Values.global.imagePullPolicy }}
         securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 10 }}
         ports:

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 global:
+  # Global image registry that will be used as fallback if component-specific registry is not set
+  # This should be the registry hostname only (e.g., "docker.io", "quay.io", "your.registry.hostname")
+  imageRegistry: ""
+
   labels:
     # Common labels for all resources
     common: {}
@@ -41,8 +45,15 @@ sharedBuffers: "32MB"
 maxPreparedTransactions: "0"
 
 image:
+  # Image registry hostname (overrides global.imageRegistry if set)
+  registry: ""
+  # Image repository path within the registry
   repository: bitnami/postgresql
+  # Image tag
   tag: 12.3.0-debian-10-r70
+  # Image digest (overrides tag if set)
+  digest: ""
+  # Image pull policy
   pullPolicy: IfNotPresent
 
 resources:

--- a/templates/_common.tpl
+++ b/templates/_common.tpl
@@ -18,3 +18,30 @@ imagePullSecrets:
     {{ .Release.Name }}-postgresql
   {{- end -}}
 {{- end -}}
+
+{{/*
+Construct the full image name following the Bitnami pattern.
+Usage: {{ include "common.image" (dict "imageRoot" .Values.path.to.image "global" .Values.global) }}
+Parameters:
+  - imageRoot: The image configuration object (must contain: registry, repository, tag, digest)
+  - global: The global values object (must contain: imageRegistry)
+Returns: registry/repository:tag or registry/repository@digest
+*/}}
+{{- define "common.image" -}}
+  {{- $registryName := .imageRoot.registry -}}
+  {{- if not $registryName -}}
+    {{- $registryName = .global.imageRegistry -}}
+  {{- end -}}
+  {{- $repositoryName := .imageRoot.repository -}}
+  {{- $separator := ":" -}}
+  {{- $termination := .imageRoot.tag | toString -}}
+  {{- if .imageRoot.digest -}}
+    {{- $separator = "@" -}}
+    {{- $termination = .imageRoot.digest | toString -}}
+  {{- end -}}
+  {{- if $registryName -}}
+    {{- printf "%s/%s%s%s" $registryName $repositoryName $separator $termination -}}
+  {{- else -}}
+    {{- printf "%s%s%s" $repositoryName $separator $termination -}}
+  {{- end -}}
+{{- end -}}

--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -53,7 +53,7 @@ spec:
       securityContext: {{ .Values.podSecurityContext | toYaml | nindent 8 }}
       containers:
       - name: haproxy
-        image: {{ .Values.haproxy.image.repository }}:{{ .Values.haproxy.image.tag }}
+        image: {{ include "common.image" (dict "imageRoot" .Values.haproxy.image "global" .Values.global) }}
         imagePullPolicy: {{ .Values.haproxy.image.pullPolicy | default .Values.global.imagePullPolicy }}
         securityContext: {{ .Values.haproxy.containerSecurityContext | toYaml | nindent 10 }}
         ports:
@@ -66,7 +66,7 @@ spec:
         - name: ha-proxy-config
           mountPath: /usr/local/etc/haproxy
       - name: keycloak
-        image: {{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}
+        image: {{ include "common.image" (dict "imageRoot" .Values.global.image "global" .Values.global) }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy | default .Values.global.imagePullPolicy }}
         securityContext: {{  .Values.containerSecurityContext | toYaml | nindent 10 }}
         args:
@@ -103,7 +103,7 @@ spec:
         {{- include "keycloak.db.certificates.volumeMount" $ | indent 8 }}
       initContainers:
       - name: "check-database"
-        image: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
+        image: {{ include "common.image" (dict "imageRoot" .Values.postgresql.image "global" .Values.global) }}
         imagePullPolicy: {{ .Values.postgresql.image.pullPolicy | default .Values.global.imagePullPolicy }}
         securityContext: {{ .Values.postgresql.containerSecurityContext | toYaml | nindent 10 }}
         command: ['/bin/bash']

--- a/values.yaml
+++ b/values.yaml
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 global:
+  # Global image registry that will be used as fallback if component-specific registry is not set
+  # This should be the registry hostname only (e.g., "docker.io", "quay.io", "your.registry.hostname")
+  imageRegistry: ""
   #volumeName: "pvcNameToOverride"
   domain: ""
   labels:
@@ -22,9 +25,17 @@ global:
     annotations: {}
       # external-dns.alpha.kubernetes.io/target: ""
       # kubernetes.io/ingress.class: ""
+  # Keycloak image configuration
   image:
-    repository: iris_keycloak
+    # Image registry hostname (overrides global.imageRegistry if set)
+    registry: ""
+    # Image repository path within the registry (e.g., "bitnami/keycloak", "myorg/keycloak")
+    repository: keycloak/keycloak
+    # Image tag
     tag: 1.1.2
+    # Image digest (overrides tag if set, e.g., "sha256:abc123...")
+    digest: ""
+    # Image pull policy
     pullPolicy: IfNotPresent
   # If imagePullSecrets is not empty, a pull secret will be deployed for each entry otherwise
   # no pull secret will be deployed
@@ -246,8 +257,15 @@ prometheus:
 
 haproxy:
   image:
+    # Image registry hostname (overrides global.imageRegistry if set)
+    registry: ""
+    # Image repository path within the registry
     repository: haproxy
+    # Image tag
     tag: 3.1.6-alpine
+    # Image digest (overrides tag if set)
+    digest: ""
+    # Image pull policy
     pullPolicy: IfNotPresent
   containerSecurityContext: {}
   resources:
@@ -260,8 +278,15 @@ haproxy:
 
 postgresql:
   image:
+    # Image registry hostname (overrides global.imageRegistry if set)
+    registry: ""
+    # Image repository path within the registry
     repository: bitnami/postgresql
+    # Image tag
     tag: 12.3.0-debian-10-r70
+    # Image digest (overrides tag if set)
+    digest: ""
+    # Image pull policy
     pullPolicy: IfNotPresent
   containerSecurityContext: {}
 


### PR DESCRIPTION
Basically, users should have an out-of-the-box experience with all Helm charts provided by the Open Telekom Integration platform. This means that as soon as there is a new Helm chart version, it should be possible to roll it out without having to manually adjust the image tag(s). In other words, the tag in the `values.yaml` file should always reference an image version that is compatible with the Helm chart's version.  

When there is a new software release, the tag in the Helm chart should also be updated accordingly (note: this process can also be automated in the future).
For the gateway chart, this is currently not the case, and this issue is being addressed as part of refactoring efforts.  
See also: [GitHub Issue: telekom/gateway-kong-charts/#6](https://github.com/telekom/gateway-kong-charts/issues/6)  

There is an effort to streamline this image value structure across all charts (creating consistent behavior). For this purpose, I have created this draft PR.  
The changes are based on the proposal from the PR on the gateway chart.

It’s still a draft and requires coordination with the teams.