### PR TITLE
fix: add config option for KEDA object name

### DIFF
--- a/templates/keda.yml
+++ b/templates/keda.yml
@@ -13,7 +13,7 @@ spec:
   maxReplicaCount: {{ .Values.autoscaling.maxReplicas }}
   pollingInterval: {{ .Values.autoscaling.pollingInterval }}
   scaleTargetRef:
-    name: iris
+    name: {{ .Release.Name }}
   triggers:
   {{- if .Values.prometheus.enabled }}
   - type: prometheus


### PR DESCRIPTION
This PR makes it possible to configure the KEDA object name to support multiple apps in the same namespace.