### PR TITLE
feat: harmonize the way image specfic configuration will be set and used

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Default settings in this template are prepared for non-prod environments.
 |-----------------------------|--------------|
 | Keycloak                    | 26.0.8       |
 | java                        | 17.0.9       |
-| PostgreSQL                  | 12.3         |
+| PostgreSQL                  | 16.6         |
 
 ## Description
 

--- a/charts/postgresql/templates/_common.tpl
+++ b/charts/postgresql/templates/_common.tpl
@@ -2,11 +2,7 @@
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{- range .Values.global.imagePullSecrets }}
-{{- if not (kindIs "string" .) }}
-  - name: {{ $.Release.Name }}-{{ .name }}
-{{- else }}
   - name: {{ . }}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/postgresql/templates/_images.tpl
+++ b/charts/postgresql/templates/_images.tpl
@@ -1,0 +1,46 @@
+{{/*
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
+
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{/*
+Image helpers for PostgreSQL chart.
+*/}}
+
+{{/*
+Generic image builder helper that constructs image reference with cascading global/override pattern.
+Supports flexible image paths:
+- With registry and namespace: {registry}/{namespace}/{repository}:{tag}
+- With registry only: {registry}/{repository}:{tag}
+- Without registry/namespace: {repository}:{tag}
+Usage: include "images.build" (dict "root" $ "imageConfig" .Values.image)
+Note: Explicitly setting registry or namespace to empty string ("") will override global defaults
+*/}}
+{{- define "postgresql.images.build" -}}
+{{- $registry := "" -}}
+{{- $namespace := "" -}}
+{{- if hasKey .imageConfig "registry" -}}
+  {{- $registry = .imageConfig.registry -}}
+{{- else -}}
+  {{- $registry = .root.Values.global.image.registry -}}
+{{- end -}}
+{{- if hasKey .imageConfig "namespace" -}}
+  {{- $namespace = .imageConfig.namespace -}}
+{{- else -}}
+  {{- $namespace = .root.Values.global.image.namespace -}}
+{{- end -}}
+{{- $repository := .imageConfig.repository -}}
+{{- $tag := .imageConfig.tag -}}
+{{- if and $registry $namespace -}}
+{{- printf "%s/%s/%s:%s" $registry $namespace $repository $tag -}}
+{{- else if $registry -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "postgresql.images.postgresql" -}}
+{{- include "postgresql.images.build" (dict "root" . "imageConfig" .Values.image) -}}
+{{- end -}}

--- a/charts/postgresql/templates/deployment.yml
+++ b/charts/postgresql/templates/deployment.yml
@@ -35,8 +35,8 @@ spec:
         resources: {{ .Values.resources | toYaml | nindent 10 }}
         env:
         {{- include "postgresql.env" $ | indent 8 }}
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-        imagePullPolicy: {{ .Values.image.pullPolicy | default .Values.global.imagePullPolicy }}
+        image: {{ include "postgresql.images.postgresql" . }}
+        imagePullPolicy: {{ .Values.imagePullPolicy | default .Values.global.imagePullPolicy }}
         securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 10 }}
         ports:
         - containerPort: {{ .Values.global.database.port | default 5432 }}

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,8 +15,22 @@ global:
       # Labels for monitoring database services
       database: {}
 
-  imagePullSecrets: []
+  # Default registry and namespace for all images
+  # Can be overridden per component (e.g., image.registry)
+  #
+  # Images are constructed as: {registry}/{namespace}/{repository}:{tag}
+  image:
+    # -- Default registry for all images
+    registry: ""
+    # -- Default namespace for all images
+    namespace: ""
 
+  # -- Array of existing pull secret names to reference for image pulling
+  # Secrets must be created outside this chart and exist in the same namespace
+  # Example: ["my-registry-secret", "another-secret"]
+  imagePullSecrets:
+
+  # -- global default for imagePullPolicy
   imagePullPolicy: IfNotPresent
 
   database:
@@ -40,10 +54,16 @@ sharedBuffers: "32MB"
 # setting this parameter to zero (default) disables the prepared-transaction feature
 maxPreparedTransactions: "0"
 
+# -- PostgreSQL image configuration (inherits global.image.registry and global.image.namespace)
 image:
-  repository: bitnami/postgresql
-  tag: 12.3.0-debian-10-r70
-  pullPolicy: IfNotPresent
+  # To use official PostgreSQL from Docker Hub, set both registry and namespace to empty:
+  registry: ""
+  namespace: ""
+  repository: postgres
+  tag: "16.6"
+
+# -- Image pull policy for PostgreSQL container
+imagePullPolicy: IfNotPresent
 
 resources:
   limits:

--- a/templates/_common.tpl
+++ b/templates/_common.tpl
@@ -2,11 +2,7 @@
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
 {{- range .Values.global.imagePullSecrets }}
-{{- if not (kindIs "string" .) }}
-  - name: {{ $.Release.Name }}-{{ .name }}
-{{- else }}
   - name: {{ . }}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/templates/_images.tpl
+++ b/templates/_images.tpl
@@ -1,0 +1,55 @@
+{{/*
+SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
+
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{/*
+Image helpers for all container images used in the chart.
+All helpers follow the naming pattern: images.<component>
+*/}}
+
+{{/*
+Generic image builder helper that constructs image reference with cascading global/override pattern.
+Supports flexible image paths:
+- With registry and namespace: {registry}/{namespace}/{repository}:{tag}
+- With registry only: {registry}/{repository}:{tag}
+- Without registry/namespace: {repository}:{tag}
+Usage: include "images.build" (dict "root" $ "imageConfig" .Values.<component>.image)
+Note: Explicitly setting registry or namespace to empty string ("") will override global defaults
+*/}}
+{{- define "images.build" -}}
+{{- $registry := "" -}}
+{{- $namespace := "" -}}
+{{- if hasKey .imageConfig "registry" -}}
+  {{- $registry = .imageConfig.registry -}}
+{{- else -}}
+  {{- $registry = .root.Values.global.image.registry -}}
+{{- end -}}
+{{- if hasKey .imageConfig "namespace" -}}
+  {{- $namespace = .imageConfig.namespace -}}
+{{- else -}}
+  {{- $namespace = .root.Values.global.image.namespace -}}
+{{- end -}}
+{{- $repository := .imageConfig.repository -}}
+{{- $tag := .imageConfig.tag -}}
+{{- if and $registry $namespace -}}
+{{- printf "%s/%s/%s:%s" $registry $namespace $repository $tag -}}
+{{- else if $registry -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "images.keycloak" -}}
+{{- include "images.build" (dict "root" . "imageConfig" .Values.image) -}}
+{{- end -}}
+
+{{- define "images.haproxy" -}}
+{{- include "images.build" (dict "root" . "imageConfig" .Values.haproxy.image) -}}
+{{- end -}}
+
+{{- define "images.postgresql" -}}
+{{- include "images.build" (dict "root" . "imageConfig" .Values.postgresql.image) -}}
+{{- end -}}

--- a/templates/configmap-haproxy.yaml
+++ b/templates/configmap-haproxy.yaml
@@ -31,7 +31,7 @@ data:
         # http-request deny if block_url_param
         default_backend be_http_default
 
-{{ if ge .Values.global.image.tag "1.1.2" }}
+{{ if ge .Values.image.tag "1.1.2" }}
         # from Iris image version 1.1.2 health endpoint are exposed on separate port
         # route health paths to management backend
         acl health_path path -m beg /auth/health # the path should start with '/auth/health'
@@ -66,7 +66,7 @@ data:
         http-request set-path /auth/realms/master/metrics
         server s1 127.0.0.1:8080
 
-{{ if ge .Values.global.image.tag "1.1.2" }}
+{{ if ge .Values.image.tag "1.1.2" }}
     backend be_http_management # management port of Keycloak
         mode http
         server s1 127.0.0.1:9000

--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -53,8 +53,8 @@ spec:
       securityContext: {{ .Values.podSecurityContext | toYaml | nindent 8 }}
       containers:
       - name: haproxy
-        image: {{ .Values.haproxy.image.repository }}:{{ .Values.haproxy.image.tag }}
-        imagePullPolicy: {{ .Values.haproxy.image.pullPolicy | default .Values.global.imagePullPolicy }}
+        image: {{ include "images.haproxy" . }}
+        imagePullPolicy: {{ .Values.haproxy.imagePullPolicy | default .Values.global.imagePullPolicy }}
         securityContext: {{ .Values.haproxy.containerSecurityContext | toYaml | nindent 10 }}
         ports:
         - { containerPort: 9090, protocol: TCP, name: http }
@@ -66,8 +66,8 @@ spec:
         - name: ha-proxy-config
           mountPath: /usr/local/etc/haproxy
       - name: keycloak
-        image: {{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}
-        imagePullPolicy: {{ .Values.global.image.pullPolicy | default .Values.global.imagePullPolicy }}
+        image: {{ include "images.keycloak" . }}
+        imagePullPolicy: {{ .Values.imagePullPolicy | default .Values.global.imagePullPolicy }}
         securityContext: {{  .Values.containerSecurityContext | toYaml | nindent 10 }}
         args:
           - "start"
@@ -103,8 +103,8 @@ spec:
         {{- include "keycloak.db.certificates.volumeMount" $ | indent 8 }}
       initContainers:
       - name: "check-database"
-        image: {{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}
-        imagePullPolicy: {{ .Values.postgresql.image.pullPolicy | default .Values.global.imagePullPolicy }}
+        image: {{ include "images.postgresql" . }}
+        imagePullPolicy: {{ .Values.postgresql.imagePullPolicy | default .Values.global.imagePullPolicy }}
         securityContext: {{ .Values.postgresql.containerSecurityContext | toYaml | nindent 10 }}
         command: ['/bin/bash']
         args: ['-c', 'until pg_isready -U {{ .Values.global.database.username }}; do echo waiting for database; sleep 2; done;']

--- a/values.yaml
+++ b/values.yaml
@@ -22,17 +22,24 @@ global:
     annotations: {}
       # external-dns.alpha.kubernetes.io/target: ""
       # kubernetes.io/ingress.class: ""
+
+  # Default registry and namespace for all images
+  # Can be overridden per component (e.g., image.registry, haproxy.image.registry)
+  #
+  # Images are constructed as: {registry}/{namespace}/{repository}:{tag}
+  # Example: mtr.devops.telekom.de/eu_it_co_development/o28m/identity-iris-keycloak:1.1.2
   image:
-    repository: iris_keycloak
-    tag: 1.1.2
-    pullPolicy: IfNotPresent
-  # If imagePullSecrets is not empty, a pull secret will be deployed for each entry otherwise
-  # no pull secret will be deployed
-  imagePullSecrets: []
-  #- name: secret
-  #  registry: https://<your-registry>
-  #  username: changeme
-  #  password: changeme
+    # -- Default registry for all images
+    registry: ""
+    # -- Default namespace for all images
+    namespace: ""
+
+  # -- Array of existing pull secret names to reference for image pulling
+  # Secrets must be created outside this chart and exist in the same namespace
+  # Example: ["my-registry-secret", "another-secret"]
+  imagePullSecrets:
+
+  # -- global default for imagePullPolicy
   imagePullPolicy: IfNotPresent
 
   # Configuration for external secrets integration (e.g., HashiCorp Vault, AWS Secrets Manager, etc.)
@@ -54,6 +61,20 @@ global:
 # This makes sense if you change configMaps or secrets, and you
 # want your deployment to use the latest configuration
 templateChangeTriggers: []
+
+# -- Keycloak image configuration (inherits global.image.registry and global.image.namespace)
+image:
+  # To override global defaults, set registry and/or namespace:
+  # registry: "my-registry.example.com"
+  # namespace: "my-namespace"
+  # To use a public image without namespace, set both to empty:
+  # registry: ""
+  # namespace: ""
+  repository: identity-iris-keycloak
+  tag: "1.1.2"
+
+# -- Image pull policy for Keycloak container
+imagePullPolicy: IfNotPresent
 
 podSecurityContext: {}
 containerSecurityContext: {}
@@ -253,10 +274,17 @@ prometheus:
     #honorLabels: ""
 
 haproxy:
+  # -- HAProxy image configuration (inherits global.image.registry and global.image.namespace)
   image:
+    # To use official HAProxy from Docker Hub, set both registry and namespace to empty:
+    # registry: ""
+    # namespace: ""
     repository: haproxy
-    tag: 3.1.6-alpine
-    pullPolicy: IfNotPresent
+    tag: "3.1.6-alpine"
+
+  # -- Image pull policy for HAProxy container
+  imagePullPolicy: IfNotPresent
+
   containerSecurityContext: {}
   resources:
     limits:
@@ -267,10 +295,17 @@ haproxy:
       cpu: 250m
 
 postgresql:
+  # -- PostgreSQL image configuration (inherits global.image.registry and global.image.namespace)
   image:
-    repository: bitnami/postgresql
-    tag: 12.3.0-debian-10-r70
-    pullPolicy: IfNotPresent
+    # To use official PostgreSQL from Docker Hub, set both registry and namespace to empty:
+    # registry: ""
+    # namespace: ""
+    repository: postgres
+    tag: "16.6"
+
+  # -- Image pull policy for PostgreSQL container
+  imagePullPolicy: IfNotPresent
+
   containerSecurityContext: {}
 
   maxPreparedTransactions: "100"


### PR DESCRIPTION
Continuation of the draft in https://github.com/telekom/identity-iris-keycloak-charts/pull/34.

_With the latest PR draft https://github.com/telekom/gateway-kong-charts/pull/23 for the gateway chart, we moved away from the Bitnami approach to structuring image references in the chart. As a result, the proposed changes in this PR draft are no longer up to date._

_The gateway Helm chart's approach aims to ensure that the Helm chart can be used immediately by our current users (with MTR access) with minimal to no value adjustments. However, the changes in the draft set "mtr.devops.telekom.de/eu_it_co_development/o28m/:" as the default, meaning that non-MTR users must explicitly override the registry and namespace._

I’m not entirely happy with setting the default to point to a private registry, so I would like to challenge this again.

In any case, this draft is not intended to be merged as a PR, but rather to serve as a basis for discussion.  
I have closed the previous draft: https://github.com/telekom/identity-iris-keycloak-charts/pull/34.