### PR TITLE
feat: added metricRelabelings for monitoring resources

### DIFF
--- a/templates/pod-monitor.yaml
+++ b/templates/pod-monitor.yaml
@@ -10,6 +10,10 @@ spec:
   podMetricsEndpoints:
     - port: metrics-http
       path: {{ .Values.prometheus.path | default "/metrics" }}
+      {{- with .Values.prometheus.podMonitor.metricRelabelings }}
+      metricRelabelings:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- if .Values.prometheus.podMonitor.scheme }}
       scheme: {{ .Values.prometheus.podMonitor.scheme }}
       {{- end }}

--- a/templates/service-monitor.yaml
+++ b/templates/service-monitor.yaml
@@ -15,6 +15,10 @@ spec:
   endpoints:
     - port: metrics-http
       path: {{ .Values.prometheus.path | default "/metrics" }}
+      {{- with .Values.prometheus.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- if .Values.prometheus.serviceMonitor.scheme }}
       scheme: {{ .Values.prometheus.serviceMonitor.scheme }}
       {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -235,6 +235,7 @@ prometheus:
   serviceMonitor:
     enabled: true
     targetLabels: []
+    metricRelabelings: []
     #selector: "guardians-raccoon"
     #scheme: http
     #interval: "15s"
@@ -242,6 +243,7 @@ prometheus:
     #honorLabels: ""
   podMonitor:
     enabled: false
+    metricRelabelings: []
     #selector: ""
     #scheme: http
     #interval: "15s"


### PR DESCRIPTION
Hey there!

We've got a required label for monitoring on application metrics, so I included metric relabelings in the 2 monitoring resources and the values file. They have yaml templating so it can be simply used like this:

```yaml
prometheus:
  enabled: true

  podMonitor:
    enabled: true
    metricRelabelings:
      - action: replace
        targetLabel: example-label-key
        replacement: example-label-value
    [...]
```