### PR TITLE
feat(template): add configuration option for revision history limit

### DIFF
--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -19,6 +19,7 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicas }}
   {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels: {{ include "keycloak.selector" $ | nindent 6 }}
   template:

--- a/values.yaml
+++ b/values.yaml
@@ -51,6 +51,8 @@ global:
 # want your deployment to use the latest configuration
 templateChangeTriggers: []
 
+revisionHistoryLimit: 10
+
 podSecurityContext: {}
 containerSecurityContext: {}
 


### PR DESCRIPTION
This PR adds configuration option for revision history limit.

The default option keeps up to 10 deployments, potentially generating a lot of garbage. The default still remains 10 to be backward compatible, but also allows to keep less deployments if it makes sense to do so.