### PR TITLE
fix: added condition for servicemonitor targetLabels

### DIFF
--- a/templates/service-monitor.yaml
+++ b/templates/service-monitor.yaml
@@ -49,5 +49,7 @@ spec:
       {{- if .Values.prometheus.serviceMonitor.honorLabels }}
       honorLabels: {{ .Values.prometheus.serviceMonitor.honorLabels }}
       {{- end }}
+  {{- if .Values.prometheus.serviceMonitor.targetLabels }}  
   targetLabels: {{ include "service-monitor.targetLabels" $ | nindent 2 }}
+  {{- end }}
 {{- end -}}


### PR DESCRIPTION
Hello all,

I tried installing all of our charts with the new Helm v4, and it has some new values issues when it's rendered with "null". This is such a case, as it's an empty array by default, and fails on new installs due to this.

As it's an optional value, I've just added a check to make sure it's defined now before using it.