### PR TITLE
feat: upgrade iris to 1.5.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@
 apiVersion: v2
 name: iris_keycloak
 version: 2.0.1
-appVersion: 1.4.1
+appVersion: 1.5.0
 keywords:
   - iris_keycloak
 dependencies:

--- a/templates/_keycloak.tpl
+++ b/templates/_keycloak.tpl
@@ -70,8 +70,6 @@ checksum/{{ . }}: {{ include (print $.Template.BasePath "/" . ) $ | sha256sum }}
   value: "false"
 - name: KC_METRICS_ENABLED
   value: "true"
-- name: KC_HTTP_METRICS_HISTOGRAMS_ENABLED
-  value: "true"
 - name: URI_METRICS_ENABLED
   value: "true"
 - name: CLIENT_AUTH_METHOD_METRICS_ENABLED

--- a/values.yaml
+++ b/values.yaml
@@ -24,7 +24,7 @@ global:
       # kubernetes.io/ingress.class: ""
   image:
     repository: iris_keycloak
-    tag: 1.4.1
+    tag: 1.5.0
     pullPolicy: IfNotPresent
   # pull secrets has to be deployed independently
   imagePullSecrets: []
@@ -69,7 +69,19 @@ clientAuthMethodMetricsEnabled: "false"
 
 # Options could be found in documentation: https://www.keycloak.org/server/configuration
 # Some environments vars are already configured in: ./templates/_keycloak.tpl
-keycloakExtraEnvVars: []
+keycloakExtraEnvVars:
+  - name: KC_HTTP_METRICS_HISTOGRAMS_ENABLED
+    value: "true"
+  - name: KC_HTTP_METRICS_SLOS
+    value: 5,10,25,50,250,500,1000,2500,5000,10000
+  - name: KC_EVENT_METRICS_USER_ENABLED
+    value: 'true'
+  - name: KC_EVENT_METRICS_USER_EVENTS
+    value: login,logout
+  - name: KC_EVENT_METRICS_USER_TAGS
+    value: realm,clientId
+  - name: QUARKUS_MICROMETER_BINDER_HTTP_SERVER_IGNORE_PATTERNS
+    value: /auth/health.*,/auth/metrics
   # - name: KC_LOG_CONSOLE_OUTPUT
   #   value: json
 
@@ -260,7 +272,14 @@ prometheus:
   serviceMonitor:
     enabled: true
     targetLabels: []
-    metricRelabelings: []
+    metricRelabelings:
+      - metricRelabelings:
+        - action: drop
+          regex: http_server_requests_seconds_bucket;(.{6,})
+          separator: ;
+          sourceLabels:
+            - __name__
+            - le
     #selector: "guardians-raccoon"
     #scheme: http
     #interval: "15s"
@@ -268,7 +287,14 @@ prometheus:
     #honorLabels: ""
   podMonitor:
     enabled: false
-    metricRelabelings: []
+    metricRelabelings:
+      - metricRelabelings:
+        - action: drop
+          regex: http_server_requests_seconds_bucket;(.{6,})
+          separator: ;
+          sourceLabels:
+            - __name__
+            - le
     #selector: ""
     #scheme: http
     #interval: "15s"

--- a/values.yaml
+++ b/values.yaml
@@ -273,13 +273,12 @@ prometheus:
     enabled: true
     targetLabels: []
     metricRelabelings:
-      - metricRelabelings:
-        - action: drop
-          regex: http_server_requests_seconds_bucket;(.{6,})
-          separator: ;
-          sourceLabels:
-            - __name__
-            - le
+      - action: drop
+        regex: http_server_requests_seconds_bucket;(.{6,})
+        separator: ;
+        sourceLabels:
+          - __name__
+          - le
     #selector: "guardians-raccoon"
     #scheme: http
     #interval: "15s"
@@ -288,13 +287,12 @@ prometheus:
   podMonitor:
     enabled: false
     metricRelabelings:
-      - metricRelabelings:
-        - action: drop
-          regex: http_server_requests_seconds_bucket;(.{6,})
-          separator: ;
-          sourceLabels:
-            - __name__
-            - le
+      - action: drop
+        regex: http_server_requests_seconds_bucket;(.{6,})
+        separator: ;
+        sourceLabels:
+          - __name__
+          - le
     #selector: ""
     #scheme: http
     #interval: "15s"


### PR DESCRIPTION
- upgrade iris to 1.5.0
- enable user events metrics
- define custom bucket for server histogram metrics
- remove metrics and health urls from server metrics