### PR TITLE
feat: do expose of http metrics optional

### DIFF
--- a/templates/pod-monitor.yaml
+++ b/templates/pod-monitor.yaml
@@ -29,6 +29,7 @@ spec:
       {{- if .Values.prometheus.podMonitor.honorLabels }}
       honorLabels: {{ .Values.prometheus.podMonitor.honorLabels }}
       {{- end }}
+    {{- if .Values.prometheus.httpMetricsEnabled }}
     - port: http
       path: "/auth/realms/master/metrics"
       {{- with .Values.prometheus.podMonitor.metricRelabelings }}
@@ -47,6 +48,7 @@ spec:
       {{- if .Values.prometheus.podMonitor.honorLabels }}
       honorLabels: {{ .Values.prometheus.podMonitor.honorLabels }}
       {{- end }}
+    {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/templates/service-metrics.yml
+++ b/templates/service-metrics.yml
@@ -12,10 +12,12 @@ spec:
   type: ClusterIP
   selector: {{ include "keycloak.selector" $ | nindent 4 }}
   ports:
+  {{- if .Values.prometheus.httpMetricsEnabled }}
   - name: metrics-http
     port: 8080
     protocol: TCP
     targetPort: http
+  {{- end }}
   - name: metrics-mgmt
     port: 9000
     protocol: TCP

--- a/templates/service-monitor.yaml
+++ b/templates/service-monitor.yaml
@@ -37,6 +37,7 @@ spec:
       {{- if .Values.prometheus.serviceMonitor.honorLabels }}
       honorLabels: {{ .Values.prometheus.serviceMonitor.honorLabels }}
       {{- end }}
+    {{- if .Values.prometheus.httpMetricsEnabled }}
     - port: metrics-http
       path: "/auth/realms/master/metrics"
       {{- with .Values.prometheus.serviceMonitor.metricRelabelings }}
@@ -55,6 +56,7 @@ spec:
       {{- if .Values.prometheus.serviceMonitor.honorLabels }}
       honorLabels: {{ .Values.prometheus.serviceMonitor.honorLabels }}
       {{- end }}
+    {{- end }}
   {{- if .Values.prometheus.serviceMonitor.targetLabels }}
   targetLabels: {{ include "service-monitor.targetLabels" $ | nindent 2 }}
   {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -303,6 +303,7 @@ prometheus:
   authToken: changeme
   # podMonitor is used to provide a PodMonitor CRD to integrate with prometheus operator
   # prometheus has to be enabled to use this
+  httpMetricsEnabled: false
   serviceMonitor:
     enabled: true
     targetLabels: []


### PR DESCRIPTION
- keycloak spi metrics are marked as deprecated and it isn't by default part of iris image anymore. It still can be enabled during building of image